### PR TITLE
Initialize project with vite setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # workspace-html
+
+## Using Vite for Page Previews
+
+To preview your pages during development, you can use Vite, a modern front-end build tool. It provides a fast development environment with hot module replacement (HMR).
+
+### Getting Started
+
+1. Install dependencies by running `npm install`.
+2. Start the development server with `npm run dev`.
+3. Open your browser to the URL provided in the terminal to view your page.
+
+Vite will automatically reload the page when changes are made to your files, allowing for a seamless development experience.
+
+### Previewing Pages Without Auto-Open
+
+To preview your pages without Vite automatically opening them in your browser:
+
+1. Ensure you have Vite installed by following the "Getting Started" instructions.
+2. Use the command `npm run preview` to start the Vite preview server.
+3. Manually navigate to the provided URL in your browser to view your page.
+
+This setup allows you to control when and how you view your page previews.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello World</title>
+</head>
+<body>
+    hello world
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "workspace-html",
+  "version": "1.0.0",
+  "description": "A project to demonstrate static HTML page with Vite",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --no-open"
+  },
+  "devDependencies": {
+    "vite": "^2.9.18"
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: './',
+  build: {
+    outDir: 'dist',
+  },
+  server: {
+    open: false,
+  },
+});


### PR DESCRIPTION
Related to #1

This pull request introduces the initial setup for the `workspace-html` project, including a static HTML page, Vite configuration for development and preview, and updated documentation.

- **Adds a static HTML page** with "hello world" as its content in `index.html`, establishing the project's entry point.
- **Introduces Vite for development and preview purposes**, with a `package.json` file that includes Vite as a development dependency and scripts for development (`dev`), build (`build`), and preview (`preview` with `--no-open` option to prevent automatic browser opening).
- **Configures Vite** to not automatically open the browser on preview with a `vite.config.js` file, ensuring the development environment meets the project's requirements.
- **Updates the README.md** to provide instructions on using Vite for page previews, including steps for starting the development server and previewing pages without auto-open, enhancing the project's documentation for better developer guidance.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tz-playground/workspace-html/issues/1?shareId=edcad892-51ed-4ce6-aa9c-a66d15d045a1).